### PR TITLE
Blog: Exporting conversations as a knowledge base

### DIFF
--- a/_posts/2026-01-18-exporting-conversations-as-a-knowledge-base.md
+++ b/_posts/2026-01-18-exporting-conversations-as-a-knowledge-base.md
@@ -1,0 +1,121 @@
+---
+layout: post
+title: "Exporting conversations as a knowledge base"
+date: 2026-01-18
+tags: [architecture, systems-thinking]
+excerpt: "Your AI conversations hold institutional knowledge. Getting it out is harder than it sounds."
+---
+
+## The Messy Reality
+
+Six months into using Claude Code on our team, I realized something uncomfortable: the most useful documentation we'd written wasn't in Notion or our wiki. It was scattered across hundreds of AI conversations.
+
+Someone had figured out the exact incantation to make our legacy payment processor work. Another developer had walked through a gnarly race condition with Claude and landed on a fix we'd all forgotten about. I'd personally had conversations explaining our domain model that were clearer than anything in our actual docs.
+
+All of it trapped in individual chat histories. Unsearchable. Unshared. Slowly rotting as context.
+
+## What's Actually Happening
+
+When you use an AI assistant for real work, you're not just getting answers—you're creating artifacts. The conversation itself becomes a record of:
+
+- Problems you've encountered (and how you framed them)
+- Solutions you arrived at (and why)
+- Decisions you made (and the context around them)
+- Domain knowledge you had to explain to get useful help
+
+This is institutional knowledge in its rawest form. The stuff that usually lives in people's heads until they leave.
+
+The problem is that chat interfaces are optimized for the conversation, not the aftermath. Export options tend to be afterthoughts: dump to JSON, maybe markdown if you're lucky. What you get is a wall of text that captures everything and organizes nothing.
+
+## The Pattern
+
+This is a transformation problem with a familiar shape: you have unstructured source material (conversations) and you want structured output (searchable knowledge).
+
+```
+Raw Conversations → Extract → Transform → Load → Searchable KB
+```
+
+The naive approach is to dump everything and hope search saves you. This works until it doesn't—usually around conversation #50 when you're drowning in false positives and can't remember which thread had the thing you need.
+
+A slightly better approach acknowledges that conversations have natural structure:
+
+```python
+# Rough shape of what extraction might look like
+@dataclass
+class ConversationSegment:
+    topic: str
+    problem_statement: str | None
+    solution: str | None
+    code_snippets: list[str]
+    decisions: list[str]
+    tags: list[str]
+
+def extract_segments(conversation: Conversation) -> list[ConversationSegment]:
+    """
+    Break a conversation into topically coherent chunks.
+    This is where the hard work lives.
+    """
+    # The messy reality: conversations meander.
+    # You might discuss three topics, circle back to the first,
+    # then end on something completely different.
+    ...
+```
+
+The transformation step is where you decide what's worth keeping. Not every "thanks, that worked!" needs to be in your knowledge base.
+
+## Why This Keeps Showing Up
+
+A few forces make this problem persistent:
+
+**Chat UX is write-optimized.** The product goal is to make conversations feel natural. Exportability is a feature for power users, not the core experience. This isn't wrong—it's just a tradeoff.
+
+**Knowledge work is messy.** The same conversation might contain a critical architectural decision, some debugging dead-ends, and a tangent about whether tabs or spaces matter for YAML. Separating signal from noise requires understanding what "signal" means for your team.
+
+**Context is expensive.** The reason the conversation was useful in the first place is because you provided context—your codebase, your constraints, your domain. An exported conversation without that context is just two people (well, one person and an AI) talking past each other.
+
+**Nobody owns this.** It's not quite a tooling problem, not quite a process problem, not quite a documentation problem. So it falls through the cracks.
+
+## What Helps
+
+I don't have a clean solution, but here's what's worked for us:
+
+**Treat exports as raw material, not finished goods.** When I export a conversation that had something valuable, I spend 5 minutes extracting the useful bits into an actual document. The export is an artifact; the doc is the knowledge.
+
+**Tag conversations while you're having them.** Some tools let you add titles or tags. Use them. "Debugging payment retry logic" is more useful than "Chat 47."
+
+**Build a habit, not a system.** We tried setting up automated pipelines to ingest conversations. It became maintenance burden that nobody wanted. What actually worked: a team norm of "if Claude helped you figure something out, spend 5 minutes writing it down somewhere findable."
+
+**Use conversations to draft documentation.** If you explained something well enough for Claude to help you, you've probably written half a doc already. Copy-paste, clean up, ship.
+
+For teams that want something more structured, the pattern looks like:
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   Export        │────▶│   Chunking &    │────▶│   Searchable    │
+│   Conversations │     │   Embedding     │     │   Vector Store  │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+                               │
+                               ▼
+                        ┌─────────────────┐
+                        │   Manual        │
+                        │   Curation      │
+                        └─────────────────┘
+```
+
+But honestly? I've seen this pattern attempted more than I've seen it work well. The teams that get value usually have someone who cares enough to maintain it.
+
+## What I'm Still Unsure About
+
+A few open questions I keep circling back to:
+
+**Is this actually a problem worth solving systematically?** Maybe the right answer is that conversations are ephemeral by nature, and forcing them into a knowledge base loses something essential. Maybe the value was in having the conversation, not preserving it.
+
+**Who should own the solution?** Should AI providers build better export tools? Should third-party tooling fill the gap? Should teams just accept this as part of their documentation process?
+
+**What's the right granularity?** Whole conversations? Individual messages? Extracted "insights"? Each choice has tradeoffs.
+
+The system behaves exactly as designed—optimized for having conversations, not for remembering them. Whether that's a bug or a feature depends on what you're trying to build.
+
+---
+
+*This post was AI-assisted but human-curated. The irony of using Claude to write about exporting Claude conversations is not lost on me.*


### PR DESCRIPTION
Explores how to extract conversations and structure them as a searchable knowledge base for future reference