### PR TITLE
Blog: Why polling agents beat event-driven for personal productivity

### DIFF
--- a/_posts/2026-01-30-why-polling-agents-beat-event-driven-for-personal-.md
+++ b/_posts/2026-01-30-why-polling-agents-beat-event-driven-for-personal-.md
@@ -1,0 +1,93 @@
+---
+layout: post
+title: "Why polling agents beat event-driven for personal productivity"
+date: 2026-01-30
+tags: [architecture, python, startup]
+excerpt: "Event-driven architecture is often the 'correct' solution, but for personal productivity agents, simple polling wins on every dimension that matters."
+---
+
+The instinct is understandable: you want your productivity tools to react *instantly*. A Slack message arrives, a file changes, a PR gets approved—your agent should respond immediately. Event-driven architecture is the textbook answer.
+
+For personal productivity systems, this instinct is usually wrong.
+
+## The appeal of event-driven
+
+Event-driven architectures offer theoretical advantages: real-time responsiveness, efficient resource usage, clean decoupling. When building systems at scale—chat applications, trading platforms, IoT networks—these properties matter.
+
+Personal productivity tools occupy a different design space. The "events" are sparse (a few per hour, not per second). The consumer is one person. The cost of five-second latency is approximately zero.
+
+## What event-driven actually costs
+
+Setting up webhooks, message queues, or file watchers for personal tools introduces complexity that compounds:
+
+**Integration fragility.** Each data source (Slack, GitHub, email, calendar) requires its own webhook configuration. These break silently when tokens expire, endpoints change, or rate limits shift. Debugging involves checking N different services.
+
+**State synchronization.** Events can arrive out of order, get duplicated, or go missing. Personal systems rarely need exactly-once semantics, but event-driven architectures force you to think about them anyway.
+
+**Deployment complexity.** Webhook receivers need to be publicly reachable. For a personal tool running on your laptop, this means tunneling, port forwarding, or cloud deployment—infrastructure overhead that doesn't serve the goal.
+
+**Testing difficulty.** Simulating the full event flow for a personal system means mocking webhooks, timing, and ordering. Polling-based tests are just "call the function, check the result."
+
+## What polling actually provides
+
+A polling agent checks sources on an interval:
+
+```python
+async def supervisor_loop():
+    while True:
+        for workstream in registry.list(status="active"):
+            state = await gather_state(workstream)
+            if needs_attention(state):
+                notify(workstream, state)
+        await asyncio.sleep(60)
+```
+
+This is the entire architecture. No webhook endpoints, no message brokers, no retry queues.
+
+**Uniform interface.** Every data source—Slack, GitHub, local files, external APIs—gets fetched the same way. The agent doesn't care whether the underlying service supports webhooks.
+
+**Graceful degradation.** If one source is temporarily unavailable, the next polling cycle tries again. No dead letter queues, no circuit breakers, no exponential backoff configuration.
+
+**Observability.** The current state is the result of the last poll. There's no hidden event log to replay, no "what events did I miss?" debugging. State is legible.
+
+**Portable.** The agent runs anywhere with network access. No firewall rules, no DNS configuration, no cloud infrastructure. `python agent.py` on any machine.
+
+## When the tradeoff changes
+
+Polling has a real cost: latency. If your use case requires sub-second response times, polling won't work. But for personal productivity:
+
+- Slack message triage can wait 60 seconds
+- PR status checks can wait 5 minutes
+- Calendar conflicts can be detected hourly
+
+The question is whether the latency matters *to you*, not whether it matters in the abstract.
+
+Polling also has a resource cost: repeated API calls. For personal tools hitting rate-limited APIs, this is usually fine. If you're polling once per minute, you're making 1,440 requests per day per source—well within typical limits.
+
+## The hybrid escape hatch
+
+If one specific source needs real-time response, add a webhook for that source while keeping everything else polling-based:
+
+```python
+@app.route("/webhook/urgent-slack")
+def handle_urgent():
+    # Fast path for one specific channel
+    process_urgent_message(request.json)
+    return "ok"
+
+async def normal_polling_loop():
+    # Everything else runs on interval
+    ...
+```
+
+This captures the benefit of event-driven where it matters while keeping the system simple where it doesn't.
+
+## The deeper pattern
+
+Event-driven architecture optimizes for properties (real-time, efficiency, scale) that personal tools don't need. Polling optimizes for properties (simplicity, portability, debuggability) that personal tools do need.
+
+The "correct" architecture depends on what you're optimizing for. For a productivity agent running on your laptop, watching your handful of active projects, simplicity wins.
+
+---
+
+*This post was written with AI assistance.*

--- a/_queue.md
+++ b/_queue.md
@@ -38,7 +38,7 @@ Ideas for blog posts. When drafted, move to "In Progress". When merged, move to 
 ### Architecture
 - [ ] Building a personal agent system with Claude Code `architecture` `python`
 - [ ] The spec-driven development pattern - design docs as contracts `architecture` `startup`
-- [ ] Why polling agents beat event-driven for personal productivity `architecture` `python`
+- [c] Why polling agents beat event-driven for personal productivity `architecture` `python`
 - [ ] Aggregate state vs. individual entities - knowing when identity matters `architecture` `design-patterns`
 - [ ] Trigger-based vs. view-based accumulation `architecture` `healthcare`
 - [ ] Personal infrastructure that follows you `architecture` `startup`


### PR DESCRIPTION
Event-driven architecture is often the 'correct' solution, but for personal productivity agents, simple polling wins on every dimension that matters.