### PR TITLE
Add Mermaid diagram rendering support

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,5 +15,19 @@
 
     {%- include footer.html -%}
 
+    <script type="module">
+      import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+      mermaid.initialize({ startOnLoad: false });
+      // kramdown wraps ```mermaid blocks in <pre><code class="language-mermaid">
+      document.querySelectorAll('code.language-mermaid').forEach(el => {
+        const pre = el.parentElement;
+        const div = document.createElement('div');
+        div.classList.add('mermaid');
+        div.textContent = el.textContent;
+        pre.replaceWith(div);
+      });
+      await mermaid.run();
+    </script>
+
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds Mermaid.js (v11, ESM) to the default layout so fenced ```mermaid``` code blocks render as diagrams
- Script runs on page load: finds kramdown-generated `<code class="language-mermaid">` elements, replaces them with `<div class="mermaid">`, and calls `mermaid.run()`
- No-op on pages without mermaid blocks

## Test plan
- [ ] Verify mermaid diagrams render on the "When Fast Beats Smart" post
- [ ] Verify pages without mermaid blocks are unaffected